### PR TITLE
Upgrade | Use `saloonphp/saloon` instead of `Sammyjo20/Saloon`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.1",
-        "sammyjo20/saloon": "^1.6"
+        "saloonphp/saloon": "^1.6"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.5",


### PR DESCRIPTION
Hey! Awesome SDK - I recently just changed the organization that Saloon lives under to "saloonphp". I have updated this package accordingly.