### PR TITLE
Feat/20250424 upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 .php-cs-fixer.cache
 .phpunit.result.cache
 tests/cache
+.phpunit.cache

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ $response = $carbone->templates()->upload($contentBase64);
 $templateId = $response->getTemplateId();
 ```
 
+You can also specify the conservation time for this template. By default, the template will not be deleted in production (30 days in test mode). You can set the conservation time in seconds using the `carbone-template-delete-after` header like this :
+
+```php
+$response = $carbone->templates()->upload($contentBase64, [
+    'carbone-template-delete-after' => 86400, // 86400s = 1 day
+]);
+
+$templateId = $response->getTemplateId();
+```
+
+> See [Carbone API documentation](https://carbone.io/documentation/developer/http-api/introduction.html#template-storage) for more information about template storage.
+
 Example to [upload a template](./examples/upload_template.php)
 
 ### Render a template
@@ -49,18 +61,30 @@ $response = $carbone->renders()->render($templateId, $data);
 
 $renderId = $response->getRenderId();
 ```
-Example to [render a template](./examples/render_report.php)
 
-### Download a rendered template
+In case of asynchronous rendering process, you can specify a webhook URL to be notified when the rendering is finished.
+The webhook URL will receive a POST request with the `success`  and the `render ID` in the body.
 
-You can download a rendered template using the `download` method. This method takes the `render ID` as a parameter.
+You can also specify custom headers for the webhook request, like authentication, using the `carbone-webhook-header-X` header. The `X` can be replaced by any custom header name.
 
 ```php
-$response = $carbone->renders()->download($renderId);
+// use a simple webhook URL
+$response = $carbone->renders()->render($templateId, $data, [
+    'carbone-webhook-url' => 'https://my-server.com/webhook',
+]);
 
-// Save the contents of the file yourself on your filesystem
-$content = $response->getContent();
+// use a webhook URL with custom headers
+$response = $carbone->renders()->render($templateId, $data, [
+    'carbone-webhook-url' => 'https://my-server.com/webhook',
+    // this will be sent as `Authorization: my-token` in the webhook request
+    'carbone-webhook-header-authorization' => 'my-token',
+]);
+
+$renderId = $response->getRenderId();
 ```
+
+> See [Carbone API documentation](https://carbone.io/documentation/developer/http-api/introduction.html#api-webhook) for more information about webhooks.
+
 Example to [download a rendered document](./examples/download_report.php)
 
 ### Render and directly download a rendered template
@@ -112,6 +136,9 @@ $carbone->setHeaders([
   // "carbone-webhook-url" => "https://my-server", // https://carbone.io/api-reference.html#api-webhook
 ]);
 ```
+
+> **Note:** custom headers applied this way will affect all requests made by this instance of the Carbone class. If you want to set custom headers for a specific request, you can do it by passing the headers as an array in `Upload a template` and `Render a template
+` requests. 
 
 ### Get API Status
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,24 @@ $content = $response->getContent();
 ```
 Example to [download a rendered document](./examples/download_report.php)
 
+### Render and directly download a rendered template
+
+You can render and download a render in the same request using the `renderAndDownload` method. This method takes the `template ID`  and render data as parameters.
+
+```php
+$templateId = "your_template_id";
+$data = [
+  'name' => 'John Doe',
+  'age' => 30,
+];
+
+$response = $carbone->renders()->renderAndDownload($templateId, $data);
+
+// Save the contents of the file yourself on your filesystem
+$content = $response->getContent();
+```
+Example to [render and download a document](./examples/render_and_download_report.php)
+
 ### Delete a template
 
 You can delete a template using the `delete` method. This method takes the `template Id` as a parameter.

--- a/examples/delete_template.php
+++ b/examples/delete_template.php
@@ -5,7 +5,7 @@ use Carboneio\SDK\Carbone;
 /** Get your API key on your Carbone account: https://account.carbone.io/. **/
 $carbone = new Carbone('PRIVATE_API_KEY');
 
-$templateId = "b0126ca004a93dd78c85cbeafb15dd3b9d64ce728c04712adea195c93681ceff";
+$templateId = 'b0126ca004a93dd78c85cbeafb15dd3b9d64ce728c04712adea195c93681ceff';
 
 /** Delete the template */
 $response = $carbone->templates()->delete($templateId);
@@ -13,9 +13,9 @@ $result = $response->json();
 
 /** If the template does not exist */
 if ($result['success'] == false) {
-  echo "Details: " . $result['error'] . "\n";
-  echo 'Carbone Error code: ' . $result['code'];
+    echo 'Details: ' . $result['error'] . "\n";
+    echo 'Carbone Error code: ' . $result['code'];
 } else {
-  /** Success! */
-  echo "Deletion succeed!\n";
+    /** Success! */
+    echo "Deletion succeed!\n";
 }

--- a/examples/download_report.php
+++ b/examples/download_report.php
@@ -6,17 +6,17 @@ use Carboneio\SDK\Carbone;
 $carbone = new Carbone('PRIVATE_API_KEY');
 
 /** Render ID */
-$renderID = "b0126ca004a93dd78c85cbeafb15dd3b9d64ce728c04712adea195c93681ceff";
+$renderID = 'b0126ca004a93dd78c85cbeafb15dd3b9d64ce728c04712adea195c93681ceff';
 
 $response = $carbone->renders()->download($renderId);
 
 /** If the file is found: Save the contents of the file yourself on your filesystem */
 if ($response->status() !== 404) {
-  // To get the custom file name provided through the rendering option "reportName":
-  echo "File name: " . $response->header('content-disposition');
-  // Save file
-  file_put_contents($renderId, $response->body());
-  echo "File saved! ✅";
+    // To get the custom file name provided through the rendering option "reportName":
+    echo 'File name: ' . $response->header('content-disposition');
+    // Save file
+    file_put_contents($renderId, $response->body());
+    echo 'File saved! ✅';
 } else {
-  echo "File not saved!";
+    echo 'File not saved!';
 }

--- a/examples/download_template.php
+++ b/examples/download_template.php
@@ -5,18 +5,18 @@ use Carboneio\SDK\Carbone;
 /** Get your API key on your Carbone account: https://account.carbone.io/. **/
 $carbone = new Carbone('PRIVATE_API_KEY');
 
-$templateId = "b0126ca004a93dd78c85cbeafb15dd3b9d64ce728c04712adea195c93681ceff";
+$templateId = 'b0126ca004a93dd78c85cbeafb15dd3b9d64ce728c04712adea195c93681ceff';
 
 /** Download the template based on the template ID */
 $response = $carbone->templates()->download($templateId);
 
-echo "Request Status Code: " . $response->status() . "\n";
+echo 'Request Status Code: ' . $response->status() . "\n";
 
 /** If the file is found: Save the contents of the file yourself on your filesystem */
 if ($response->status() !== 404) {
-  file_put_contents('template.odt', $response->body());
-  echo "File saved! ✅";
-  /** If the file is not found */
+    file_put_contents('template.odt', $response->body());
+    echo 'File saved! ✅';
+    /** If the file is not found */
 } else {
-  echo "File not saved!";
+    echo 'File not saved!';
 }

--- a/examples/render_and_download_report.php
+++ b/examples/render_and_download_report.php
@@ -21,18 +21,16 @@ $data = [
   'convertTo' => 'pdf',
 ];
 
-/** Generate the document */
-$response = $carbone->renders()->render($templateId, $data);
-$result = $response->json();
-echo 'Request Status Code: ' . $response->status() . "\n";
+/** Generate the document and download it with the same request */
+$response = $carbone->renders()->renderAndDownload($templateId, $data);
 
-/** Handle errors */
-if ($result['success'] == false) {
-    echo 'Something went wrong: ' . $result['error'] . "\n";
+/** If the file is found: Save the contents of the file yourself on your filesystem */
+if ($response->status() !== 404) {
+    // To get the custom file name provided through the rendering option "reportName":
+    echo 'File name: ' . $response->header('content-disposition');
+    // Save file
+    file_put_contents('/my_super_doc.pdf', $response->body());
+    echo 'File saved! ✅';
 } else {
-    /**
-     * Success, save the render ID:
-     * The render ID is a unique id to download a the generate document
-     */
-    echo $response->getRenderId();
+    echo 'File not saved!';
 }

--- a/examples/render_report.php
+++ b/examples/render_report.php
@@ -36,3 +36,17 @@ if ($result['success'] == false) {
      */
     echo $response->getRenderId();
 }
+
+/** You can also specify custom headers for async render support via webhook */
+
+// use a simple webhook URL
+$response = $carbone->renders()->render($templateId, $data, [
+    'carbone-webhook-url' => 'https://my-server.com/webhook',
+]);
+
+// use a webhook URL with custom headers
+$response = $carbone->renders()->render($templateId, $data, [
+    'carbone-webhook-url' => 'https://my-server.com/webhook',
+    // this will be sent as `Authorization: my-token` in the webhook request
+    'carbone-webhook-header-authorization' => 'my-token',
+]);

--- a/examples/upload_template.php
+++ b/examples/upload_template.php
@@ -20,3 +20,8 @@ echo 'Template ID ' . $response->getTemplateId();
  * - Delete the template
  * - Download the template
  */
+
+/** You can alternatively specify the conservation time for this template in seconds */
+$response = $carbone->templates()->upload($templateAsBase64, [
+    'carbone-template-delete-after' => 86400, // 86400s = 1 day
+]);

--- a/examples/upload_template.php
+++ b/examples/upload_template.php
@@ -6,13 +6,13 @@ use Carboneio\SDK\Carbone;
 $carbone = new Carbone('PRIVATE_API_KEY');
 
 /** Load the local file and compute the template content as base64 */
-$templateAsBase64 = base64_encode(file_get_contents("./template.odt"));
+$templateAsBase64 = base64_encode(file_get_contents('./template.odt'));
 
 /** Upload the file */
 $response = $carbone->templates()->upload($templateAsBase64);
 
 /** Get template ID */
-echo "Template ID " . $response->getTemplateId();
+echo 'Template ID ' . $response->getTemplateId();
 
 /**
  * From the template ID you can:

--- a/src/Carbone.php
+++ b/src/Carbone.php
@@ -3,19 +3,19 @@
 namespace Carboneio\SDK;
 
 /** Carboneio SDK Class */
-use Carboneio\SDK\Responses\CarboneSdkResponse;
+use Saloon\Http\Response;
 
 /** Carbone SDK Collections */
-use Carboneio\SDK\RequestsCollection\RendersCollection;
-use Carboneio\SDK\RequestsCollection\TemplatesCollection;
-use Carboneio\SDK\Requests\StatusRequest;
+use Saloon\Http\Connector;
+use Saloon\Contracts\Authenticator;
+use Saloon\Traits\Plugins\AcceptsJson;
 
 /** Saloon Class */
-use Saloon\Http\Connector;
-use Saloon\Traits\Plugins\AcceptsJson;
 use Saloon\Http\Auth\TokenAuthenticator;
-use Saloon\Http\Response;
-use Saloon\Contracts\Authenticator;
+use Carboneio\SDK\Requests\StatusRequest;
+use Carboneio\SDK\Responses\CarboneSdkResponse;
+use Carboneio\SDK\RequestsCollection\RendersCollection;
+use Carboneio\SDK\RequestsCollection\TemplatesCollection;
 
 class Carbone extends Connector
 {
@@ -42,7 +42,7 @@ class Carbone extends Connector
      */
     protected array $requests = [
         'templates' => TemplatesCollection::class,
-        'renders' => RendersCollection::class
+        'renders' => RendersCollection::class,
     ];
 
     /**
@@ -91,7 +91,7 @@ class Carbone extends Connector
     public function defaultConfig(): array
     {
         return [
-            'timeout' => 30
+            'timeout' => 30,
         ];
     }
 

--- a/src/Requests/Reports/DownloadReportRequest.php
+++ b/src/Requests/Reports/DownloadReportRequest.php
@@ -3,11 +3,11 @@
 namespace Carboneio\SDK\Requests\Reports;
 
 /** Saloon Class */
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
 use Saloon\Constants\Saloon;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
-use Saloon\Http\Request;
-use Saloon\Enums\Method;
 
 class DownloadReportRequest extends Request implements HasBody
 {

--- a/src/Requests/Reports/RenderAndDownloadReportRequest.php
+++ b/src/Requests/Reports/RenderAndDownloadReportRequest.php
@@ -10,15 +10,12 @@ use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
 /** Carbone SDK Class */
-use Carboneio\SDK\Responses\RenderReportResponse;
 
-class RenderReportRequest extends Request implements HasBody
+class RenderAndDownloadReportRequest extends Request implements HasBody
 {
     use HasJsonBody;
 
     protected Method $method = Method::POST;
-
-    protected ?string $response = RenderReportResponse::class;
 
     public function __construct(
         private string $templateId,
@@ -34,5 +31,12 @@ class RenderReportRequest extends Request implements HasBody
     public function defaultBody(): array
     {
         return $this->data;
+    }
+
+    protected function defaultQuery(): array
+    {
+        return [
+            'download' => 'true',
+        ];
     }
 }

--- a/src/Requests/Reports/RenderReportRequest.php
+++ b/src/Requests/Reports/RenderReportRequest.php
@@ -22,7 +22,8 @@ class RenderReportRequest extends Request implements HasBody
 
     public function __construct(
         private string $templateId,
-        private array $data
+        private array $data,
+        private array $additionalHeaders = []
     ) {
     }
 
@@ -34,5 +35,10 @@ class RenderReportRequest extends Request implements HasBody
     public function defaultBody(): array
     {
         return $this->data;
+    }
+
+    protected function defaultHeaders(): array
+    {
+        return $this->additionalHeaders;
     }
 }

--- a/src/Requests/StatusRequest.php
+++ b/src/Requests/StatusRequest.php
@@ -3,11 +3,11 @@
 namespace Carboneio\SDK\Requests;
 
 /** Saloon Class */
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
 use Saloon\Constants\Saloon;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
-use Saloon\Http\Request;
-use Saloon\Enums\Method;
 
 class StatusRequest extends Request implements HasBody
 {
@@ -15,7 +15,8 @@ class StatusRequest extends Request implements HasBody
 
     protected Method $method = Method::GET;
 
-    public function __construct() {
+    public function __construct()
+    {
     }
 
     public function resolveEndpoint(): string

--- a/src/Requests/Templates/DeleteTemplateRequest.php
+++ b/src/Requests/Templates/DeleteTemplateRequest.php
@@ -3,11 +3,11 @@
 namespace Carboneio\SDK\Requests\Templates;
 
 /** Saloon Class */
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
 use Saloon\Constants\Saloon;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
-use Saloon\Http\Request;
-use Saloon\Enums\Method;
 
 class DeleteTemplateRequest extends Request implements HasBody
 {

--- a/src/Requests/Templates/DownloadTemplateRequest.php
+++ b/src/Requests/Templates/DownloadTemplateRequest.php
@@ -3,11 +3,11 @@
 namespace Carboneio\SDK\Requests\Templates;
 
 /** Saloon Class */
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
 use Saloon\Constants\Saloon;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
-use Saloon\Http\Request;
-use Saloon\Enums\Method;
 
 class DownloadTemplateRequest extends Request implements HasBody
 {

--- a/src/Requests/Templates/UploadTemplateRequest.php
+++ b/src/Requests/Templates/UploadTemplateRequest.php
@@ -3,11 +3,11 @@
 namespace Carboneio\SDK\Requests\Templates;
 
 /** Saloon Class */
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
 use Saloon\Constants\Saloon;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
-use Saloon\Http\Request;
-use Saloon\Enums\Method;
 
 /** Carbone SDK Class */
 use Carboneio\SDK\Responses\UploadTemplateResponse;

--- a/src/Requests/Templates/UploadTemplateRequest.php
+++ b/src/Requests/Templates/UploadTemplateRequest.php
@@ -21,7 +21,8 @@ class UploadTemplateRequest extends Request implements HasBody
     protected ?string $response = UploadTemplateResponse::class;
 
     public function __construct(
-        private string $templateAsBase64
+        private string $templateAsBase64,
+        private array $additionalHeaders = []
     ) {
     }
 
@@ -35,5 +36,10 @@ class UploadTemplateRequest extends Request implements HasBody
         return [
             'template' => $this->templateAsBase64,
         ];
+    }
+
+    protected function defaultHeaders(): array
+    {
+        return $this->additionalHeaders;
     }
 }

--- a/src/RequestsCollection/RendersCollection.php
+++ b/src/RequestsCollection/RendersCollection.php
@@ -33,8 +33,8 @@ class RendersCollection
         return $this->connector->send(new DownloadReportRequest($renderId));
     }
 
-    public function renderAndDownload(string $templateId, array $data, array $additionalHeaders = []): CarboneSdkResponse
+    public function renderAndDownload(string $templateId, array $data): CarboneSdkResponse
     {
-        return $this->connector->send(new RenderAndDownloadReportRequest($templateId, $data, $additionalHeaders));
+        return $this->connector->send(new RenderAndDownloadReportRequest($templateId, $data));
     }
 }

--- a/src/RequestsCollection/RendersCollection.php
+++ b/src/RequestsCollection/RendersCollection.php
@@ -3,15 +3,16 @@
 namespace Carboneio\SDK\RequestsCollection;
 
 /** Requests */
-use Carboneio\SDK\Requests\Reports\RenderReportRequest;
-use Carboneio\SDK\Requests\Reports\DownloadReportRequest;
 
-/** Responses */
+use Saloon\Http\Connector;
 use Carboneio\SDK\Responses\CarboneSdkResponse;
 use Carboneio\SDK\Responses\RenderReportResponse;
 
-use Saloon\Repositories\RequestCollection;
-use Saloon\Http\Connector;
+/** Responses */
+use Carboneio\SDK\Requests\Reports\RenderReportRequest;
+use Carboneio\SDK\Requests\Reports\DownloadReportRequest;
+
+use Carboneio\SDK\Requests\Reports\RenderAndDownloadReportRequest;
 
 class RendersCollection
 {
@@ -31,5 +32,9 @@ class RendersCollection
     {
         return $this->connector->send(new DownloadReportRequest($renderId));
     }
-}
 
+    public function renderAndDownload(string $templateId, array $data): CarboneSdkResponse
+    {
+        return $this->connector->send(new RenderAndDownloadReportRequest($templateId, $data));
+    }
+}

--- a/src/RequestsCollection/RendersCollection.php
+++ b/src/RequestsCollection/RendersCollection.php
@@ -23,9 +23,9 @@ class RendersCollection
         $this->connector = $connector;
     }
 
-    public function render(string $templateId, array $data): RenderReportResponse
+    public function render(string $templateId, array $data, array $additionalHeaders = []): RenderReportResponse
     {
-        return $this->connector->send(new RenderReportRequest($templateId, $data));
+        return $this->connector->send(new RenderReportRequest($templateId, $data, $additionalHeaders));
     }
 
     public function download(string $renderId): CarboneSdkResponse
@@ -33,8 +33,8 @@ class RendersCollection
         return $this->connector->send(new DownloadReportRequest($renderId));
     }
 
-    public function renderAndDownload(string $templateId, array $data): CarboneSdkResponse
+    public function renderAndDownload(string $templateId, array $data, array $additionalHeaders = []): CarboneSdkResponse
     {
-        return $this->connector->send(new RenderAndDownloadReportRequest($templateId, $data));
+        return $this->connector->send(new RenderAndDownloadReportRequest($templateId, $data, $additionalHeaders));
     }
 }

--- a/src/RequestsCollection/TemplatesCollection.php
+++ b/src/RequestsCollection/TemplatesCollection.php
@@ -22,9 +22,9 @@ class TemplatesCollection
         $this->connector = $connector;
     }
 
-    public function upload(string $content): UploadTemplateResponse
+    public function upload(string $content, array $additionalHeaders = []): UploadTemplateResponse
     {
-        return $this->connector->send(new UploadTemplateRequest($content));
+        return $this->connector->send(new UploadTemplateRequest($content, $additionalHeaders));
     }
 
     public function delete(string $templateId): CarboneSdkResponse

--- a/src/RequestsCollection/TemplatesCollection.php
+++ b/src/RequestsCollection/TemplatesCollection.php
@@ -3,16 +3,15 @@
 namespace Carboneio\SDK\RequestsCollection;
 
 /** Requests */
-use Carboneio\SDK\Requests\Templates\DeleteTemplateRequest;
-use Carboneio\SDK\Requests\Templates\DownloadTemplateRequest;
-use Carboneio\SDK\Requests\Templates\UploadTemplateRequest;
-
-/** Responses */
+use Saloon\Http\Connector;
 use Carboneio\SDK\Responses\CarboneSdkResponse;
 use Carboneio\SDK\Responses\UploadTemplateResponse;
 
-use Saloon\Repositories\RequestCollection;
-use Saloon\Http\Connector;
+/** Responses */
+use Carboneio\SDK\Requests\Templates\DeleteTemplateRequest;
+use Carboneio\SDK\Requests\Templates\UploadTemplateRequest;
+
+use Carboneio\SDK\Requests\Templates\DownloadTemplateRequest;
 
 class TemplatesCollection
 {

--- a/tests/DeleteTemplateTest.php
+++ b/tests/DeleteTemplateTest.php
@@ -2,23 +2,23 @@
 
 
 /** Saloon Class */
-use Saloon\Http\Faking\MockClient;
-use Saloon\Http\Faking\MockResponse;
-
 use Carboneio\SDK\Carbone;
+use Saloon\Http\Faking\MockClient;
+
+use Saloon\Http\Faking\MockResponse;
 use Carboneio\SDK\Requests\Templates\DeleteTemplateRequest;
 
 beforeEach(function () {
-    $this->token = "jwt_carbone_token";
+    $this->token = 'jwt_carbone_token';
     $this->carbone = new Carbone($this->token);
 });
 
 it('should delete a template', function () {
 
-    $templateId = "afc1879ed3a2dbedac30e5f873d9fdb0cc13528974a7f8ec946ceaf2fbd8fdc9";
+    $templateId = 'afc1879ed3a2dbedac30e5f873d9fdb0cc13528974a7f8ec946ceaf2fbd8fdc9';
     $expectedResponse = [
-        "success" => true,
-        "data"    => "Template deleted"
+        'success' => true,
+        'data' => 'Template deleted',
     ];
 
     $mockClient = new MockClient([
@@ -32,8 +32,8 @@ it('should delete a template', function () {
 
     $this->assertEquals($json, $expectedResponse);
     expect($response->status())->toBe(200);
-    expect(isset($json["error"]))->toBe(false);
-    expect(isset($json["code"]))->toBe(false);
+    expect(isset($json['error']))->toBe(false);
+    expect(isset($json['code']))->toBe(false);
 
     $mockClient->assertSent('/template/*');
     $mockClient->assertSent(DeleteTemplateRequest::class);
@@ -41,11 +41,11 @@ it('should delete a template', function () {
 
 it('should return an error if the template does not exist anymore', function () {
 
-    $templateId = "afc1879ed3a2dbedac30e5f873d9fdb0cc13528974a7f8ec946ceaf2fbd8fdc9";
+    $templateId = 'afc1879ed3a2dbedac30e5f873d9fdb0cc13528974a7f8ec946ceaf2fbd8fdc9';
     $expectedResponse = [
-        "success" => false,
-        "data"    => "Cannot remove template, does it exist?",
-        "code"    => "w105"
+        'success' => false,
+        'data' => 'Cannot remove template, does it exist?',
+        'code' => 'w105',
     ];
 
     $mockClient = new MockClient([

--- a/tests/DownloadReportTest.php
+++ b/tests/DownloadReportTest.php
@@ -2,20 +2,20 @@
 
 
 /** Saloon Class */
-use Saloon\Http\Faking\MockClient;
-use Saloon\Http\Faking\MockResponse;
-
 use Carboneio\SDK\Carbone;
+use Saloon\Http\Faking\MockClient;
+
+use Saloon\Http\Faking\MockResponse;
 use Carboneio\SDK\Requests\Reports\DownloadReportRequest;
 
 beforeEach(function () {
-    $this->token = "jwt_carbone_token";
+    $this->token = 'jwt_carbone_token';
     $this->carbone = new Carbone($this->token);
 });
 
 it('should download a report', function () {
 
-    $renderId = "MTAuMjAuMjEuNDEgICAgOpJ9Qgp6OEl5Ea5ACsPjMAcmVwb3J0.docx";
+    $renderId = 'MTAuMjAuMjEuNDEgICAgOpJ9Qgp6OEl5Ea5ACsPjMAcmVwb3J0.docx';
     $resultContent = getResult();
 
     $mockClient = new MockClient([
@@ -35,11 +35,11 @@ it('should download a report', function () {
 
 it('should return an error if the render does not exist', function () {
 
-    $renderId = "MTAuMjAuMjEuNDEgICAgOpJ9Qgp6OEl5Ea5ACsPjMAcmVwb3J0.docx";
+    $renderId = 'MTAuMjAuMjEuNDEgICAgOpJ9Qgp6OEl5Ea5ACsPjMAcmVwb3J0.docx';
     $expectedResponse = [
-        "success" => false,
-        "data"    => "File not found",
-        "code"    => "w104"
+        'success' => false,
+        'data' => 'File not found',
+        'code' => 'w104',
     ];
 
     $mockClient = new MockClient([

--- a/tests/DownloadTemplateTest.php
+++ b/tests/DownloadTemplateTest.php
@@ -2,20 +2,20 @@
 
 
 /** Saloon Class */
-use Saloon\Http\Faking\MockClient;
-use Saloon\Http\Faking\MockResponse;
-
 use Carboneio\SDK\Carbone;
+use Saloon\Http\Faking\MockClient;
+
+use Saloon\Http\Faking\MockResponse;
 use Carboneio\SDK\Requests\Templates\DownloadTemplateRequest;
 
 beforeEach(function () {
-    $this->token = "jwt_carbone_token";
+    $this->token = 'jwt_carbone_token';
     $this->carbone = new Carbone($this->token);
 });
 
 it('should download a template', function () {
 
-    $templateId = "afc1879ed3a2dbedac30e5f873d9fdb0cc13528974a7f8ec946ceaf2fbd8fdc9";
+    $templateId = 'afc1879ed3a2dbedac30e5f873d9fdb0cc13528974a7f8ec946ceaf2fbd8fdc9';
     $templateContent = getTemplate();
 
     $mockClient = new MockClient([
@@ -35,11 +35,11 @@ it('should download a template', function () {
 
 it('should return an error if the template does not exist', function () {
 
-    $templateId = "afc1879ed3a2dbedac30e5f873d9fdb0cc13528974a7f8ec946ceaf2fbd8fdc9";
+    $templateId = 'afc1879ed3a2dbedac30e5f873d9fdb0cc13528974a7f8ec946ceaf2fbd8fdc9';
     $expectedResponse = [
-        "success" => false,
-        "data"    => "Cannot read template",
-        "code"    => "w116"
+        'success' => false,
+        'data' => 'Cannot read template',
+        'code' => 'w116',
     ];
 
     $mockClient = new MockClient([

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,7 @@
 <?php
 
-function getTemplate() : string {
+function getTemplate(): string
+{
     return file_get_contents(__DIR__ . '/Assets/template.odt');
 }
 

--- a/tests/StatusTest.php
+++ b/tests/StatusTest.php
@@ -1,28 +1,28 @@
 <?php
 
 /** Saloon Class */
-use Saloon\Http\Faking\MockClient;
-use Saloon\Http\Faking\MockResponse;
-
 use Carboneio\SDK\Carbone;
+use Saloon\Http\Faking\MockClient;
+
+use Saloon\Http\Faking\MockResponse;
 use Carboneio\SDK\Requests\StatusRequest;
 
 beforeEach(function () {
-    $this->token = "jwt_carbone_token";
+    $this->token = 'jwt_carbone_token';
     $this->carbone = new Carbone($this->token);
 });
 
 it('Should return the status 200 of the API', function () {
 
-    $expectedResponse =  [
-        "success" => true,
-        "code"    => 200,
-        "message" => "OK",
-        "version" => "4.6.7"
+    $expectedResponse = [
+        'success' => true,
+        'code' => 200,
+        'message' => 'OK',
+        'version' => '4.6.7',
     ];
 
     $mockClient = new MockClient([
-        StatusRequest::class => MockResponse::make($expectedResponse, 200)
+        StatusRequest::class => MockResponse::make($expectedResponse, 200),
     ]);
 
     $this->carbone->withMockClient($mockClient);
@@ -38,15 +38,15 @@ it('Should return the status 200 of the API', function () {
 
 it('Should return the status 500 of the API', function () {
 
-    $expectedResponse =  [
-        "success" => false,
-        "code"    => 500,
-        "message" => "/",
-        "version" => "4.6.7"
+    $expectedResponse = [
+        'success' => false,
+        'code' => 500,
+        'message' => '/',
+        'version' => '4.6.7',
     ];
 
     $mockClient = new MockClient([
-        StatusRequest::class => MockResponse::make($expectedResponse, 500)
+        StatusRequest::class => MockResponse::make($expectedResponse, 500),
     ]);
 
     $this->carbone->withMockClient($mockClient);

--- a/tests/UploadTemplateTest.php
+++ b/tests/UploadTemplateTest.php
@@ -3,29 +3,29 @@
 
 
 /** Saloon Class */
-use Saloon\Http\Faking\MockClient;
-use Saloon\Http\Faking\MockResponse;
-
 use Carboneio\SDK\Carbone;
+use Saloon\Http\Faking\MockClient;
+
+use Saloon\Http\Faking\MockResponse;
 use Carboneio\SDK\Requests\Templates\UploadTemplateRequest;
 
 beforeEach(function () {
-    $this->token = "jwt_carbone_token";
+    $this->token = 'jwt_carbone_token';
     $this->carbone = new Carbone($this->token);
 });
 
 it('should upload a template and return a template ID', function () {
 
-    $templateId = "afc1879ed3a2dbedac30e5f873d9fdb0cc13528974a7f8ec946ceaf2fbd8fdc9";
+    $templateId = 'afc1879ed3a2dbedac30e5f873d9fdb0cc13528974a7f8ec946ceaf2fbd8fdc9';
     $expectedResponse = [
-        "success" => true,
-        "data"    => [
-          "templateId" => $templateId
-        ]
+        'success' => true,
+        'data' => [
+          'templateId' => $templateId,
+        ],
     ];
 
     $mockClient = new MockClient([
-        UploadTemplateRequest::class => MockResponse::make($expectedResponse, 200)
+        UploadTemplateRequest::class => MockResponse::make($expectedResponse, 200),
     ]);
 
     $this->carbone->withMockClient($mockClient);
@@ -33,12 +33,12 @@ it('should upload a template and return a template ID', function () {
     $response = $this->carbone->templates()->upload(getTemplateAsBase64());
     $json = $response->json();
     expect($response->getTemplateId())->toBe($templateId);
-    expect($json["data"]["templateId"])->toBe($templateId);
-    expect($json["success"])->toBeTrue();
+    expect($json['data']['templateId'])->toBe($templateId);
+    expect($json['success'])->toBeTrue();
     expect($response->status())->toBe(200);
 
-    expect(isset($json["error"]))->toBe(false);
-    expect(isset($json["code"]))->toBe(false);
+    expect(isset($json['error']))->toBe(false);
+    expect(isset($json['code']))->toBe(false);
 
     $mockClient->assertSent('/template');
     $mockClient->assertSent(UploadTemplateRequest::class);
@@ -46,16 +46,17 @@ it('should upload a template and return a template ID', function () {
 
 it('should return an error if the template format is not supported', function () {
 
-    $expectedResponse =  [
-        "success" => false,
-        "error"   => "Template format not supported, it must be an XML-based document: DOCX, XLSX, PPTX, ODT, ODS, ODP, XHTML, HTML or an XML file",
-        "code"    => "w118"
+    $expectedResponse = [
+        'success' => false,
+        'error' => 'Template format not supported, it must be an XML-based document: DOCX, XLSX, PPTX, ODT, ODS, ODP, XHTML, HTML or an XML file',
+        'code' => 'w118',
     ];
 
     $mockClient = new MockClient([
         UploadTemplateRequest::class => MockResponse::make(
-        $expectedResponse,
-        200),
+            $expectedResponse,
+            200
+        ),
     ]);
 
     $this->carbone->withMockClient($mockClient);


### PR DESCRIPTION
This pull request aims to add simpliciation features to this vendor, already available in the Rest API of carbone.io.

**Added features :**
- Using the `download=true` query parameter specified in the API documentation, I added a `renderAndDownload` shorthand method to generate and download a render in the same request.
- I also added the ability to use custom headers for requests supporting it, to use template conservation times, and webhook capabilities.

I wrote all unit tests for this code, and used PHP CS Fixer to fix code linting issues.